### PR TITLE
Make running from source work on Linux and macOS (fixes #2, #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![CapCap Editor Preview](assets/preview.JPG)
 ### [Demo + Tutorial](https://www.tiktok.com/@nguyenthach617/video/7674305087023369493)
 
-CapCap is a Windows desktop video-localization editor for creating Vietnamese or English subtitles, translated video, voice-over, and timed visual layers.
+CapCap is a desktop video-localization editor for creating Vietnamese or English subtitles, translated video, voice-over, and timed visual layers. The packaged release is Windows-only; running from source also works on Linux and macOS with system FFmpeg and libmpv.
 
 ## Highlights
 
@@ -26,10 +26,20 @@ CapCap is a Windows desktop video-localization editor for creating Vietnamese or
 git clone https://github.com/notepower2k1/CapCap.git
 cd CapCap
 python -m venv venv
-venv\Scripts\activate
+venv\Scripts\activate          # Linux/macOS: source venv/bin/activate
 pip install -r requirements-local.txt
 python ui/gui.py
 ```
+
+On Linux and macOS, install FFmpeg and libmpv first - `bin/` only contains the
+Windows binaries:
+
+```bash
+sudo apt install ffmpeg libmpv2     # Debian/Ubuntu
+brew install ffmpeg mpv             # macOS
+```
+
+See [Requirements and Resources](docs/requirements.md) for the full platform notes.
 
 Copy `.env_example` to `.env` only if you need manual provider or remote-server configuration. Most settings are available in the app.
 

--- a/app/audio_mixer.py
+++ b/app/audio_mixer.py
@@ -2,15 +2,15 @@ import os
 import subprocess
 import wave
 
-from runtime_paths import bin_path
+from runtime_paths import ffmpeg_path, ffprobe_path
 
 
 def _ffmpeg_path():
-    return bin_path("ffmpeg", "ffmpeg.exe")
+    return ffmpeg_path()
 
 
 def _ffprobe_path():
-    return bin_path("ffmpeg", "ffprobe.exe")
+    return ffprobe_path()
 
 
 def _subprocess_run_kwargs() -> dict:

--- a/app/ocr_processor.py
+++ b/app/ocr_processor.py
@@ -6,7 +6,7 @@ import time
 import cv2
 import numpy as np
 
-from runtime_paths import bin_path, subprocess_hidden_kwargs
+from runtime_paths import ffmpeg_path, subprocess_hidden_kwargs
 
 _OCR_ENGINE = None
 _OCR_ENGINE_LOCK = None
@@ -121,7 +121,7 @@ def _get_lock():
 
 
 def _ffmpeg_path():
-    return os.path.join(bin_path("ffmpeg"), "ffmpeg.exe")
+    return ffmpeg_path()
 
 
 def _load_ocr_engine():

--- a/app/preview_processor.py
+++ b/app/preview_processor.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 
-from runtime_paths import bin_path
+from runtime_paths import ffmpeg_path
 from video_filter_chain import build_video_filter_chain, normalize_video_filter_state
 
 
@@ -9,7 +9,7 @@ _FFMPEG_ENCODER_CACHE = {}
 
 
 def _ffmpeg_path():
-    return bin_path("ffmpeg", "ffmpeg.exe")
+    return ffmpeg_path()
 
 
 def _subprocess_run_kwargs() -> dict:

--- a/app/runtime_paths.py
+++ b/app/runtime_paths.py
@@ -1,7 +1,11 @@
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+
+IS_WINDOWS = os.name == "nt"
 
 
 def bundle_root() -> str:
@@ -47,12 +51,95 @@ def first_existing_path(*candidates: str) -> str:
     return str(candidates[0] if candidates else "")
 
 
+def _bin_roots() -> list:
+    return [
+        os.path.join(bundle_root(), "bin"),
+        join_root("bin"),
+        os.path.join(os.getcwd(), "bin"),
+        os.path.join(os.path.dirname(os.path.abspath(sys.executable)), "bin"),
+    ]
+
+
+def _part_variants(part: str) -> list:
+    """Return the acceptable spellings of a bundled file name on this OS.
+
+    The repository ships Windows binaries (``ffmpeg.exe``), so call sites name
+    them with the ``.exe`` suffix.  On Linux and macOS the same tool has no
+    extension, and a bundled ``.exe`` is a PE image that cannot be executed, so
+    the suffixed spelling must never be accepted there.
+    """
+    name = str(part or "")
+    if IS_WINDOWS or not name.lower().endswith(".exe"):
+        return [name]
+    return [name[: -len(".exe")]]
+
+
 def bin_path(*parts: str) -> str:
-    primary = os.path.join(bundle_root(), "bin", *parts)
-    workspace_fallback = join_root("bin", *parts)
-    cwd_fallback = os.path.join(os.getcwd(), "bin", *parts)
-    exe_fallback = os.path.join(os.path.dirname(os.path.abspath(sys.executable)), "bin", *parts)
-    return first_existing_path(primary, workspace_fallback, cwd_fallback, exe_fallback)
+    if parts:
+        tail_variants = _part_variants(parts[-1])
+        head = list(parts[:-1])
+    else:
+        tail_variants = []
+        head = []
+
+    candidates = []
+    for root in _bin_roots():
+        if tail_variants:
+            for variant in tail_variants:
+                candidates.append(os.path.join(root, *head, variant))
+        else:
+            candidates.append(root)
+    return first_existing_path(*candidates)
+
+
+def tool_path(name: str, *, subdir: str = "ffmpeg") -> str:
+    """Resolve a command-line tool such as ``ffmpeg`` or ``ffprobe``.
+
+    Bundled copies win so a packaged build stays self-contained.  When nothing
+    is bundled — the normal situation on Linux and macOS, where the ``.exe``
+    binaries in ``bin/`` are unusable — fall back to the copy on ``PATH`` and
+    finally to the bare name, which yields a readable "not found" error from
+    ``subprocess`` instead of a misleading missing-file path.
+    """
+    base = str(name or "").strip()
+    if not base:
+        return ""
+    filename = base + ".exe" if IS_WINDOWS else base
+
+    for candidate in (bin_path(subdir, filename), bin_path(filename)):
+        if candidate and os.path.isfile(candidate):
+            return candidate
+
+    found = shutil.which(base)
+    if found:
+        return found
+    return base
+
+
+def ffmpeg_path() -> str:
+    return tool_path("ffmpeg")
+
+
+def ffprobe_path() -> str:
+    return tool_path("ffprobe")
+
+
+def mpv_library_path() -> str:
+    """Locate the libmpv shared library that ships with the Windows bundle.
+
+    Linux and macOS are expected to use the system libmpv (``libmpv.so.2`` /
+    ``libmpv.2.dylib``), which ``python-mpv`` discovers on its own, so an empty
+    string there means "let the loader find it".
+    """
+    if IS_WINDOWS:
+        names = ("libmpv-2.dll", "mpv-2.dll")
+    else:
+        names = ("libmpv.so.2", "libmpv.so", "libmpv.2.dylib", "libmpv.dylib")
+    for name in names:
+        candidate = bin_path("mpv", name)
+        if candidate and os.path.isfile(candidate):
+            return candidate
+    return ""
 
 
 def models_path(*parts: str) -> str:

--- a/app/services/chunking_service.py
+++ b/app/services/chunking_service.py
@@ -6,13 +6,13 @@ import subprocess
 import wave
 
 from core.models import AudioChunk
-from runtime_paths import bin_path
+from runtime_paths import ffmpeg_path
 
 
 class ChunkingService:
     def __init__(self, workspace_root: str):
         self.workspace_root = workspace_root
-        self.ffmpeg_path = bin_path("ffmpeg", "ffmpeg.exe")
+        self.ffmpeg_path = ffmpeg_path()
 
     def _subprocess_run_kwargs(self) -> dict:
         kwargs = {}

--- a/app/services/resource_download_service.py
+++ b/app/services/resource_download_service.py
@@ -9,7 +9,15 @@ import time
 import uuid
 from pathlib import Path
 
-from runtime_paths import app_path, bin_path, bundle_root, join_root, models_path, subprocess_hidden_kwargs
+from runtime_paths import (
+    app_path,
+    bin_path,
+    bundle_root,
+    ffmpeg_path as resolve_ffmpeg,
+    join_root,
+    models_path,
+    subprocess_hidden_kwargs,
+)
 
 
 class ResourceDownloadService:
@@ -389,13 +397,17 @@ class ResourceDownloadService:
     def validate_pipeline_runtime(self) -> list[tuple[str, str]]:
         """Check local executables and writable working folders before a worker starts."""
         issues: list[tuple[str, str]] = []
-        ffmpeg_path = bin_path("ffmpeg", "ffmpeg.exe")
-        if not os.path.isfile(ffmpeg_path):
-            issues.append(("ffmpeg", f"FFmpeg is missing: {ffmpeg_path}"))
+        ffmpeg_exe = resolve_ffmpeg()
+        if not shutil.which(ffmpeg_exe) and not os.path.isfile(ffmpeg_exe):
+            issues.append((
+                "ffmpeg",
+                "FFmpeg was not found. Install it and make sure it is on PATH, "
+                f"or place it in the bin/ffmpeg folder (looked for: {ffmpeg_exe}).",
+            ))
         else:
             try:
                 result = subprocess.run(
-                    [ffmpeg_path, "-version"],
+                    [ffmpeg_exe, "-version"],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                     timeout=10,

--- a/app/tts_processor.py
+++ b/app/tts_processor.py
@@ -8,7 +8,7 @@ import time
 import wave
 
 from dotenv import load_dotenv
-from runtime_paths import app_path, bin_path, bundle_root, models_path, temp_path
+from runtime_paths import app_path, bundle_root, ffmpeg_path, models_path, temp_path
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 ENV_PATH = os.path.join(os.path.dirname(BASE_DIR), ".env")
 if os.path.exists(ENV_PATH):
@@ -63,7 +63,7 @@ def _get_cached_piper_voice(*, model_path: str, on_progress: callable = None):
 
 
 def _ffmpeg_path():
-    return bin_path("ffmpeg", "ffmpeg.exe")
+    return ffmpeg_path()
 
 
 def _subprocess_run_kwargs() -> dict:

--- a/app/video_processor.py
+++ b/app/video_processor.py
@@ -1,13 +1,19 @@
 import subprocess
 import os
 import re
+import sys
 import math
 import hashlib
 import threading
 from functools import lru_cache
 
 from new_highlight_selector import auto_select_matches
-from runtime_paths import asset_path, bin_path, temp_path
+from runtime_paths import (
+    asset_path,
+    ffmpeg_path as resolve_ffmpeg,
+    ffprobe_path as resolve_ffprobe,
+    temp_path,
+)
 from video_filter_chain import (
     build_video_color_chain,
     build_video_filter_chain,
@@ -23,11 +29,11 @@ from video_filter_chain import (
 def _ffmpeg_path(override=None):
     if override:
         return override
-    return bin_path("ffmpeg", "ffmpeg.exe")
+    return resolve_ffmpeg()
 
 
 def _ffprobe_path():
-    return bin_path("ffmpeg", "ffprobe.exe")
+    return resolve_ffprobe()
 
 
 def _subprocess_run_kwargs() -> dict:
@@ -66,7 +72,7 @@ def _subtitle_metric_font(font_name: str, pixel_size: int, bold: bool):
         return None
 
     requested = re.sub(r"[^a-z0-9]", "", str(font_name or "").lower())
-    font_dirs = [asset_path("fonts"), os.path.join(os.environ.get("WINDIR", r"C:\\Windows"), "Fonts")]
+    font_dirs = [asset_path("fonts")] + _system_font_dirs()
     candidates: list[tuple[int, str]] = []
     for directory in font_dirs:
         if not directory or not os.path.isdir(directory):
@@ -90,6 +96,24 @@ def _subtitle_metric_font(font_name: str, pixel_size: int, bold: bool):
         except OSError:
             continue
     return None
+
+
+def _system_font_dirs() -> list:
+    """Directories the OS keeps installed fonts in."""
+    if os.name == "nt":
+        return [os.path.join(os.environ.get("WINDIR", r"C:\Windows"), "Fonts")]
+    if sys.platform == "darwin":
+        return [
+            os.path.expanduser("~/Library/Fonts"),
+            "/Library/Fonts",
+            "/System/Library/Fonts",
+        ]
+    return [
+        os.path.expanduser("~/.local/share/fonts"),
+        os.path.expanduser("~/.fonts"),
+        "/usr/local/share/fonts",
+        "/usr/share/fonts",
+    ]
 
 
 def _ffmpeg_supports_encoder(ffmpeg_path: str, encoder_name: str) -> bool:
@@ -134,10 +158,10 @@ def _ass_filter_expression(ass_path: str) -> str:
     if os.path.isdir(bundled_fonts) and any(name.lower().endswith((".ttf", ".otf")) for name in os.listdir(bundled_fonts)):
         escaped_fonts = _escape_path_for_filter(bundled_fonts)
         return f"ass=filename='{escaped_ass}':fontsdir='{escaped_fonts}'"
-    windows_fonts = os.path.join(os.environ.get("WINDIR", r"C:\Windows"), "Fonts")
-    if os.path.isdir(windows_fonts):
-        escaped_fonts = _escape_path_for_filter(windows_fonts)
-        return f"ass=filename='{escaped_ass}':fontsdir='{escaped_fonts}'"
+    for system_fonts in _system_font_dirs():
+        if os.path.isdir(system_fonts):
+            escaped_fonts = _escape_path_for_filter(system_fonts)
+            return f"ass=filename='{escaped_ass}':fontsdir='{escaped_fonts}'"
     return f"ass=filename='{escaped_ass}'"
 
 

--- a/app/workflows/prepare_workflow.py
+++ b/app/workflows/prepare_workflow.py
@@ -2,10 +2,11 @@ import os
 import concurrent.futures
 import hashlib
 import re
+import shutil
 import subprocess
 import time
 
-from runtime_paths import bin_path, models_path, subprocess_hidden_kwargs
+from runtime_paths import ffmpeg_path, models_path, subprocess_hidden_kwargs
 from runtime_profile import is_remote_profile
 from services import ChunkingService, EngineRuntime, ProjectService, SegmentRegroupService, SegmentService
 from services.resource_download_service import ResourceDownloadService
@@ -67,8 +68,8 @@ class PrepareWorkflow:
                 print("[ASR Audio] Reusing level analysis: normalization not needed.")
                 return source
 
-        ffmpeg = str(bin_path("ffmpeg", "ffmpeg.exe"))
-        if not os.path.exists(ffmpeg):
+        ffmpeg = str(ffmpeg_path())
+        if not shutil.which(ffmpeg) and not os.path.exists(ffmpeg):
             print("[ASR Audio] FFmpeg unavailable; skipping level normalization.")
             return source
         try:
@@ -405,7 +406,7 @@ class PrepareWorkflow:
 
             audio_output_path = self.project_service.build_path(project_state, "source", "extracted_audio.wav")
             os.makedirs(os.path.dirname(audio_output_path), exist_ok=True)
-            ffmpeg_bin = os.path.join(bin_path(), "ffmpeg", "ffmpeg.exe")
+            ffmpeg_bin = ffmpeg_path()
             subprocess.run(
                 [ffmpeg_bin, "-y", "-i", video_path, "-vn", "-acodec", "pcm_s16le",
                  "-ar", "16000", "-ac", "1", audio_output_path],
@@ -561,7 +562,7 @@ class PrepareWorkflow:
                 )
                 try:
                     ffmpeg_cmd = [
-                        str(bin_path("ffmpeg", "ffmpeg.exe")),
+                        str(ffmpeg_path()),
                         "-i", vocal_path,
                         "-af", "afftdn,loudnorm=I=-16:LRA=11:TP=-1.5",
                         "-ar", "16000",

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2,10 +2,41 @@
 
 ## System requirements
 
-- Windows 10/11
+- Windows 10/11 for the packaged release build
 - Python 3.11 when running from source
-- FFmpeg and libmpv are included in the application resources
+- FFmpeg and libmpv are included in the Windows application resources
 - CPU mode works on systems without an NVIDIA GPU
+
+### Running from source on Linux and macOS
+
+Only the packaged release is Windows-only. Running from source works on Linux
+and macOS provided FFmpeg and libmpv come from the system package manager,
+because `bin/` ships Windows `.exe` and `.dll` files that those systems cannot
+load. CapCap looks for a bundled copy first and falls back to `PATH`.
+
+| Platform | Install command |
+| --- | --- |
+| Debian/Ubuntu | `sudo apt install ffmpeg libmpv2` (`libmpv1` on older releases) |
+| Fedora | `sudo dnf install ffmpeg mpv-libs` |
+| Arch | `sudo pacman -S ffmpeg mpv` |
+| macOS (Homebrew) | `brew install ffmpeg mpv` |
+
+Verify the tools resolve before starting the app:
+
+```bash
+ffmpeg -version
+ffprobe -version
+python -c "import mpv; print('libmpv OK')"
+```
+
+Platform notes:
+
+- GPU mode is CUDA-only, so Linux needs an NVIDIA GPU and macOS is CPU-only.
+  `requirements-base.txt` installs the CPU build of `onnxruntime` automatically
+  on macOS and on non-x86_64 machines.
+- Qt needs a desktop session. On a headless or WSL host, install the usual
+  `libxcb`/`xkbcommon` runtime packages, or run under an X/Wayland server.
+- The packaged `.exe` build and the CUDA runtime pack remain Windows-only.
 
 ## GPU mode
 

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,5 +1,25 @@
+edge-tts
+soundfile
+numpy
+huggingface_hub
+faster-whisper
+vietnormalizer
+piper-tts
+# onnxruntime-gpu has no macOS wheel and no non-x86_64 wheel on PyPI, so a
+# plain `pip install` fails outright there. Fall back to the CPU package on
+# those platforms; CapCap already selects the CPU device when CUDA is absent.
+onnxruntime-gpu; platform_system != "Darwin" and platform_machine in "x86_64 AMD64"
+onnxruntime; platform_system == "Darwin" or platform_machine not in "x86_64 AMD64"
+scipy
+openai
+librosa
+rapidocr
+opencv-python-headless
+sherpa-onnx
 PySide6
 requests
 python-dotenv
 pydub
+# python-mpv is a binding only. Windows uses the libmpv shipped in bin/mpv;
+# Linux and macOS need libmpv from the system package manager.
 python-mpv

--- a/ui/controllers/preview_controller.py
+++ b/ui/controllers/preview_controller.py
@@ -2,7 +2,6 @@
 import hashlib
 import json
 import re
-import shutil
 import subprocess
 import time
 
@@ -10,7 +9,7 @@ from PySide6.QtCore import QTimer, QUrl
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import QFileDialog, QMessageBox
 
-from runtime_paths import bin_path
+from runtime_paths import ffprobe_path as resolve_ffprobe
 from worker_adapters import ExactFramePreviewWorker, FinalExportWorker, PreviewMuxWorker, QuickPreviewWorker
 
 
@@ -359,18 +358,8 @@ class PreviewController:
         return f"{value:.1f} {units[unit_idx]}"
 
     def _probe_source_fps(self, video_path: str) -> str:
-        ffprobe_candidates = [
-            bin_path("ffmpeg", "ffprobe.exe"),
-            bin_path("ffprobe.exe"),
-            shutil.which("ffprobe"),
-            shutil.which("ffprobe.exe"),
-        ]
-        ffprobe_path = ""
-        for candidate in ffprobe_candidates:
-            if candidate and os.path.isfile(candidate):
-                ffprobe_path = candidate
-                break
-        if not ffprobe_path:
+        ffprobe_exe = resolve_ffprobe()
+        if not ffprobe_exe:
             return "Unknown"
         try:
             startupinfo = None
@@ -381,7 +370,7 @@ class PreviewController:
                 creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
             result = subprocess.run(
                 [
-                    ffprobe_path,
+                    ffprobe_exe,
                     "-v",
                     "error",
                     "-select_streams",
@@ -413,12 +402,8 @@ class PreviewController:
 
     def _video_has_audio_stream(self, video_path: str) -> bool:
         """Determine whether the source audio that subtitle-only export maps exists."""
-        ffprobe_candidates = [
-            bin_path("ffmpeg", "ffprobe.exe"), bin_path("ffprobe.exe"),
-            shutil.which("ffprobe"), shutil.which("ffprobe.exe"),
-        ]
-        ffprobe_path = next((path for path in ffprobe_candidates if path and os.path.isfile(path)), "")
-        if not ffprobe_path:
+        ffprobe_exe = resolve_ffprobe()
+        if not ffprobe_exe:
             # A selected/extracted source is a safer fallback than presenting
             # a misleading “No Audio” label when ffprobe is unavailable.
             return bool(getattr(self.gui, "last_extracted_audio", ""))
@@ -430,7 +415,7 @@ class PreviewController:
                 startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
                 creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
             result = subprocess.run(
-                [ffprobe_path, "-v", "error", "-select_streams", "a:0", "-show_entries", "stream=index", "-of", "csv=p=0", video_path],
+                [ffprobe_exe, "-v", "error", "-select_streams", "a:0", "-show_entries", "stream=index", "-of", "csv=p=0", video_path],
                 capture_output=True, text=True, timeout=10,
                 startupinfo=startupinfo, creationflags=creationflags,
                 check=False,

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -2146,7 +2146,8 @@ class VideoTranslatorGUI(QMainWindow):
         from runtime_paths import models_path
         dir_path = models_path("vietnormalizer")
         os.makedirs(dir_path, exist_ok=True)
-        os.startfile(dir_path)
+        from utils.file_dialog_utils import open_path_externally
+        open_path_externally(dir_path)
 
     def _create_vietdict_template(self, resource_id: str):
         import csv
@@ -2171,7 +2172,8 @@ class VideoTranslatorGUI(QMainWindow):
                 w.writerow(["iPhone", "ai phôn"])
             print(f"[VietDict] Created template: {nonvn_path}")
 
-        os.startfile(dir_path)
+        from utils.file_dialog_utils import open_path_externally
+        open_path_externally(dir_path)
 
     def _vietdict_add_row(self, table):
         from PySide6.QtWidgets import QTableWidgetItem

--- a/ui/utils/__init__.py
+++ b/ui/utils/__init__.py
@@ -15,6 +15,7 @@ from .file_dialog_utils import (
     browse_voice_output_folder,
     cleanup_file_if_exists,
     open_folder,
+    open_path_externally,
 )
 from .media_utils import (
     browse_video,

--- a/ui/utils/file_dialog_utils.py
+++ b/ui/utils/file_dialog_utils.py
@@ -10,6 +10,28 @@ def _normalize_selected_file_path(path: str) -> str:
     return os.path.normpath(os.path.abspath(value))
 
 
+def open_path_externally(path: str) -> bool:
+    """Reveal a file or folder in the platform file manager.
+
+    ``os.startfile`` only exists on Windows, so Linux and macOS go through Qt's
+    ``QDesktopServices``, which delegates to xdg-open / Finder.
+    """
+    target = str(path or "").strip()
+    if not target:
+        return False
+    target = os.path.abspath(target)
+
+    starter = getattr(os, "startfile", None)
+    if callable(starter):
+        starter(target)
+        return True
+
+    from PySide6.QtCore import QUrl
+    from PySide6.QtGui import QDesktopServices
+
+    return bool(QDesktopServices.openUrl(QUrl.fromLocalFile(target)))
+
+
 def browse_audio_folder(gui):
     from PySide6.QtWidgets import QFileDialog
 
@@ -76,7 +98,7 @@ def open_folder(gui, path):
         if not path:
             return
         os.makedirs(path, exist_ok=True)
-        os.startfile(os.path.abspath(path))
+        open_path_externally(path)
     except Exception as exc:
         QMessageBox.critical(gui, "Error", f"Could not open folder:\n{exc}")
 

--- a/ui/utils/media_backend.py
+++ b/ui/utils/media_backend.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from PySide6.QtCore import QObject, QTimer, QUrl, Signal
 from PySide6.QtMultimedia import QAudioOutput, QMediaPlayer
 
-from runtime_paths import asset_path, bin_path, subprocess_hidden_kwargs
+from runtime_paths import asset_path, bin_path, ffprobe_path, mpv_library_path, subprocess_hidden_kwargs
 from video_processor import srt_to_ass
 try:
     # The normal launcher places ``app`` directly on sys.path.
@@ -80,8 +80,8 @@ def _realtime_color_graph(state=None) -> str:
 def _ffprobe_video_duration(video_path: str) -> float:
     """Get video duration using ffprobe as fallback."""
     try:
-        ffprobe = os.path.join(bin_path("ffmpeg"), "ffprobe.exe")
-        if not os.path.exists(ffprobe):
+        ffprobe = ffprobe_path()
+        if not ffprobe:
             return 0.0
         result = subprocess.run(
             [ffprobe, "-v", "error", "-show_entries", "format=duration",
@@ -1315,30 +1315,45 @@ def is_mpv_backend_available():
 
 
 def prepare_mpv_bundle():
+    """Make libmpv importable before ``python-mpv`` loads it.
+
+    Windows builds ship libmpv inside ``bin/mpv`` and must pre-load it so the
+    dependent runtime DLLs resolve.  Linux and macOS install libmpv through the
+    system package manager (``libmpv2`` / ``brew install mpv``), where the
+    dynamic loader already finds it, so a missing bundle there is not an error.
+    """
+    mpv_library = mpv_library_path()
+
+    if not sys.platform.startswith("win"):
+        # Honour a bundled library when one is present, otherwise defer to the
+        # system loader instead of failing the whole preview backend.
+        if mpv_library:
+            mpv_dir = str(Path(mpv_library).parent)
+            var = "DYLD_LIBRARY_PATH" if sys.platform == "darwin" else "LD_LIBRARY_PATH"
+            existing = os.environ.get(var, "")
+            if mpv_dir not in existing.split(os.pathsep):
+                os.environ[var] = mpv_dir + (os.pathsep + existing if existing else "")
+        return
+
     mpv_dir = get_mpv_bundle_dir()
     if not mpv_dir.exists():
         raise FileNotFoundError(f"Bundled mpv directory not found: {mpv_dir}")
 
-    mpv_dll = mpv_dir / "libmpv-2.dll"
-    if not mpv_dll.exists():
-        alt_dll = mpv_dir / "mpv-2.dll"
-        if alt_dll.exists():
-            mpv_dll = alt_dll
-        else:
-            raise FileNotFoundError(f"Bundled libmpv DLL not found in {mpv_dir}")
+    if not mpv_library:
+        raise FileNotFoundError(f"Bundled libmpv DLL not found in {mpv_dir}")
+    mpv_dll = Path(mpv_library)
 
     if hasattr(os, "add_dll_directory"):
         os.add_dll_directory(str(mpv_dir))
 
     os.environ["PATH"] = str(mpv_dir) + os.pathsep + os.environ.get("PATH", "")
 
-    if sys.platform.startswith("win"):
-        try:
-            import ctypes
+    try:
+        import ctypes
 
-            ctypes.WinDLL(str(mpv_dll))
-        except OSError as exc:
-            raise RuntimeError(
-                f"Could not load bundled libmpv from {mpv_dll}. "
-                "The bundle may be missing dependent runtime DLLs."
-            ) from exc
+        ctypes.WinDLL(str(mpv_dll))
+    except OSError as exc:
+        raise RuntimeError(
+            f"Could not load bundled libmpv from {mpv_dll}. "
+            "The bundle may be missing dependent runtime DLLs."
+        ) from exc

--- a/ui/views/launcher.py
+++ b/ui/views/launcher.py
@@ -94,14 +94,15 @@ def _extract_thumbnail(video_path: str, output_path: str) -> str:
 
 
 def _ffmpeg_path():
-    from runtime_paths import bin_path
-    return os.path.join(bin_path(), "ffmpeg", "ffmpeg.exe")
+    from runtime_paths import ffmpeg_path
+    return ffmpeg_path()
 
 
 def _get_video_duration(video_path: str) -> float:
     try:
         import subprocess
-        ffprobe = _ffmpeg_path().replace("ffmpeg.exe", "ffprobe.exe")
+        from runtime_paths import ffprobe_path
+        ffprobe = ffprobe_path()
         result = subprocess.run(
             [ffprobe, "-v", "error", "-show_entries", "format=duration",
              "-of", "csv=p=0", video_path],
@@ -835,13 +836,10 @@ class LauncherWindow(QDialog):
         from PySide6.QtWidgets import QMessageBox
         projects_dir = os.path.join(workspace_root(), "projects")
         try:
+            from utils.file_dialog_utils import open_path_externally
+
             os.makedirs(projects_dir, exist_ok=True)
-            if hasattr(os, "startfile"):
-                os.startfile(projects_dir)
-            else:
-                from PySide6.QtGui import QDesktopServices
-                from PySide6.QtCore import QUrl
-                QDesktopServices.openUrl(QUrl.fromLocalFile(projects_dir))
+            open_path_externally(projects_dir)
         except Exception as exc:
             message = QMessageBox(QMessageBox.Warning, "Open Project Folder",
                 f"Could not open the projects folder:\n\n{exc}", QMessageBox.Ok, self)

--- a/ui/views/resource_manager.py
+++ b/ui/views/resource_manager.py
@@ -53,8 +53,10 @@ def _open_folder_dialog(gui_parent, path: str) -> None:
         return
     from PySide6.QtWidgets import QMessageBox
     try:
+        from utils.file_dialog_utils import open_path_externally
+
         os.makedirs(target, exist_ok=True)
-        os.startfile(os.path.abspath(target))
+        open_path_externally(target)
     except Exception as exc:
         QMessageBox.critical(gui_parent, "Error", f"Could not open folder:\n{exc}")
 

--- a/ui/worker_adapters/processing_workers.py
+++ b/ui/worker_adapters/processing_workers.py
@@ -13,7 +13,13 @@ APP_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "app")
 if APP_PATH not in sys.path:
     sys.path.insert(0, APP_PATH)
 
-from runtime_paths import bin_path, subprocess_hidden_kwargs
+from runtime_paths import (
+    bin_path,
+    ffmpeg_path as resolve_ffmpeg,
+    ffprobe_path as resolve_ffprobe,
+    mpv_library_path,
+    subprocess_hidden_kwargs,
+)
 from services import EngineRuntime, ResourceDownloadService
 
 
@@ -115,7 +121,7 @@ class AlternateRangeTranscriptionWorker(QThread):
             else:
                 import tempfile
                 temp_audio = os.path.join(tempfile.gettempdir(), f"capcap_range_{int(self.start_time * 1000)}_{int(self.end_time * 1000)}.wav")
-                ffmpeg = bin_path("ffmpeg", "ffmpeg.exe")
+                ffmpeg = resolve_ffmpeg()
                 subprocess.run([
                     ffmpeg, "-hide_banner", "-loglevel", "error", "-y", "-ss", str(self.start_time),
                     "-t", str(max(0.1, self.end_time - self.start_time)), "-i", self.video_path,
@@ -305,19 +311,26 @@ class RuntimeAssetsWorker(QThread):
             details = []
 
             self.progress.emit(5, "Checking bundled runtime assets...")
-            ffmpeg_path = Path(bin_path("ffmpeg", "ffmpeg.exe"))
-            if not ffmpeg_path.exists():
-                raise FileNotFoundError(f"Bundled FFmpeg is missing: {ffmpeg_path}")
-            details.append(f"FFmpeg ready: {ffmpeg_path}")
+            ffmpeg_exe = resolve_ffmpeg()
+            if not (os.path.isfile(ffmpeg_exe) or shutil.which(ffmpeg_exe)):
+                raise FileNotFoundError(
+                    "FFmpeg was not found. Install it and make sure it is on PATH, "
+                    f"or place it in the bin/ffmpeg folder (looked for: {ffmpeg_exe})."
+                )
+            details.append(f"FFmpeg ready: {ffmpeg_exe}")
             self.progress.emit(12, "FFmpeg is ready.")
 
-            mpv_path = Path(bin_path("mpv", "libmpv-2.dll"))
-            if not mpv_path.exists():
-                alt_mpv_path = Path(bin_path("mpv", "mpv-2.dll"))
-                if not alt_mpv_path.exists():
-                    raise FileNotFoundError(f"Bundled libmpv is missing: {mpv_path}")
-                mpv_path = alt_mpv_path
-            details.append(f"libmpv ready: {mpv_path}")
+            mpv_library = mpv_library_path()
+            if mpv_library:
+                details.append(f"libmpv ready: {mpv_library}")
+            elif os.name == "nt":
+                raise FileNotFoundError(
+                    f"Bundled libmpv is missing: {bin_path('mpv', 'libmpv-2.dll')}"
+                )
+            else:
+                # Linux/macOS load libmpv from the system package manager, so
+                # the loader — not a bundled file — decides availability.
+                details.append("libmpv: using the system installation.")
             self.progress.emit(20, "Preview runtime is ready.")
 
             from whisper_processor import load_whisper_model
@@ -392,7 +405,7 @@ class TimelineWaveformWorker(QThread):
                 temp_audio = self.temp_audio_path
                 if temp_audio and not os.path.exists(temp_audio):
                     os.makedirs(os.path.dirname(temp_audio), exist_ok=True)
-                    ffmpeg = os.path.join(bin_path("ffmpeg"), "ffmpeg.exe")
+                    ffmpeg = resolve_ffmpeg()
                     subprocess.run(
                         [
                             ffmpeg,
@@ -484,19 +497,8 @@ class TimelineThumbnailWorker(QThread):
                 self.finished.emit(self.request_signature, [], "")
                 return
 
-            ffmpeg_candidates = [
-                bin_path("ffmpeg", "ffmpeg.exe"),
-                bin_path("ffmpeg.exe"),
-                shutil.which("ffmpeg"),
-                shutil.which("ffmpeg.exe"),
-            ]
-            ffmpeg_path = ""
-            for candidate in ffmpeg_candidates:
-                if candidate and os.path.isfile(candidate):
-                    ffmpeg_path = candidate
-                    break
-
-            if not ffmpeg_path:
+            ffmpeg_path = resolve_ffmpeg()
+            if not (os.path.isfile(ffmpeg_path) or shutil.which(ffmpeg_path)):
                 self.finished.emit(self.request_signature, [], "")
                 return
 
@@ -1018,8 +1020,8 @@ class VoiceSamplePreviewWorker(QThread):
             return candidate
         try:
             normalized_path = os.path.join(temp_dir, f"{Path(candidate).stem}_normalized.wav")
-            ffmpeg_path = Path(bin_path("ffmpeg", "ffmpeg.exe"))
-            if ffmpeg_path.exists():
+            ffmpeg_path = resolve_ffmpeg()
+            if os.path.isfile(ffmpeg_path) or shutil.which(ffmpeg_path):
                 cmd = [
                     str(ffmpeg_path),
                     "-y",
@@ -1052,8 +1054,8 @@ class VoiceSamplePreviewWorker(QThread):
             return False
         if os.path.getsize(candidate) <= 44:
             return False
-        ffprobe_path = Path(bin_path("ffmpeg", "ffprobe.exe"))
-        if not ffprobe_path.exists():
+        ffprobe_path = resolve_ffprobe()
+        if not (os.path.isfile(ffprobe_path) or shutil.which(ffprobe_path)):
             return True
         try:
             proc = subprocess.run(


### PR DESCRIPTION
Closes #2 (Cannot run on Linux).
Closes #3 ([Feature] Feature Request Support for Macos).

## The problem

`bin/` contains committed Windows binaries (`ffmpeg.exe`, `ffprobe.exe`), and those files are present after a clone on **every** platform. `bin_path("ffmpeg", "ffmpeg.exe")` therefore resolved successfully on Linux and macOS and handed a PE image to `subprocess`, which fails at exec time. A few other Windows-only code paths raised before the editor could open.

This PR removes those blockers so `python ui/gui.py` runs from source on Linux and macOS using system FFmpeg and libmpv. **Windows behaviour is unchanged** — bundled binaries still win, so packaged builds stay self-contained.

## Changes

**Path resolution** (`app/runtime_paths.py`)
- New `tool_path()` / `ffmpeg_path()` / `ffprobe_path()`. Bundled copy first; off-Windows the `.exe` spelling is rejected outright and the tool comes from `PATH`, degrading to the bare name so `subprocess` raises a readable "not found" instead of us passing a path that does not exist.
- `bin_path()` strips a trailing `.exe` off-Windows, so existing call sites keep working.
- Every FFmpeg/FFprobe lookup across `app/` and `ui/` now goes through the helpers instead of hardcoding `.exe`.

**libmpv** (`ui/utils/media_backend.py`, `ui/worker_adapters/processing_workers.py`)
- `prepare_mpv_bundle()` no longer raises `FileNotFoundError` when `bin/mpv` is absent. Windows keeps pre-loading the bundled DLL; Linux/macOS defer to the system libmpv that `python-mpv` already discovers, and a bundled `.so`/`.dylib` is added to the loader path if one exists.
- The startup asset check reports "using the system installation" rather than failing on a missing `libmpv-2.dll`.

**Windows-only API calls**
- `os.startfile` does not exist off-Windows and raised `AttributeError` on the four "open folder" actions. They now share `open_path_externally()`, which falls back to `QDesktopServices` — the same guard `launcher.py` already used.
- Subtitle rendering searches the platform font directories instead of only `%WINDIR%\Fonts`.

**Dependencies** (`requirements-base.txt`)
- `onnxruntime-gpu` has no macOS wheel and no non-x86_64 wheel on PyPI, so `pip install -r requirements-local.txt` failed outright on macOS before anything else could be tried. Environment markers now select the CPU `onnxruntime` there.

**Docs** — README and `docs/requirements.md` gained the Linux/macOS prerequisites and a `venv` activation note.

## Verification

- Windows resolution is byte-identical before and after (bundled `ffmpeg.exe`/`ffprobe.exe` still selected; `bin_path()` unchanged).
- A simulated POSIX host rejects the bundled `.exe`, resolves from `PATH`, prefers an extension-less bundled binary when present, and finds `libmpv.2.dylib`.
- The `onnxruntime` markers were evaluated across win-x64 / linux-x64 / linux-arm / mac-arm / mac-x64 — exactly one package installs on each.
- `compileall` clean; `pyflakes` reports no new findings versus `main`.

## Scope and caveats

I do not have a Linux or macOS machine, so I could not do a full end-to-end run there — please treat the runtime side as needing a smoke test from someone who can reproduce the original reports. Explicitly **out of scope**: the packaged `.exe` build, the CUDA runtime pack, and GPU mode on macOS all remain Windows/NVIDIA-only. This PR targets "runs from source", not "ships a Linux/macOS release".

