### PR TITLE
Fix resource detection and setup dead ends (#4, #5, #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ CapCap is a Windows desktop video-localization editor for creating Vietnamese or
 - Piper and Edge TTS, optional speaker diarization, and per-speaker voice assignment
 - Editor timeline with subtitles, blur, logo, mask, text, selection ranges, locks, and Fast Preview
 
+## Download
+
+There is no `.exe` file in this repository - the build is published as a ZIP on
+the [Releases page](https://github.com/notepower2k1/CapCap/releases/latest).
+Download the ZIP, extract it, and run `CapCap.exe` from the extracted folder.
+
+On first launch, open **Manage Resources** and install the packs marked
+*Missing*. The SenseVoice model is required before a project can be created in
+either CPU or GPU mode; the GPU Acceleration Pack is required only for GPU mode.
+
 ## Documentation
 
 - [How to Use](docs/how-to-use.md)

--- a/app/runtime_paths.py
+++ b/app/runtime_paths.py
@@ -55,6 +55,50 @@ def bin_path(*parts: str) -> str:
     return first_existing_path(primary, workspace_fallback, cwd_fallback, exe_fallback)
 
 
+def find_resource_file(root: str, filename: str, max_depth: int = 2) -> str:
+    """Locate a required file inside a resource folder, allowing nesting.
+
+    Every downloadable pack is an archive with its own top-level folder, so
+    extracting it *into* the folder the Resource Manager names produces
+    ``<target>/<archive-name>/<file>`` instead of ``<target>/<file>``. That is
+    the most common way users install these packs by hand, and an exact-path
+    check reported the resource as missing with nothing to explain why.
+
+    Returns the absolute path of the first match, or "" when there is none.
+    """
+    base = str(root or "").strip()
+    name = str(filename or "").strip()
+    if not base or not name or not os.path.isdir(base):
+        return ""
+
+    direct = os.path.join(base, name)
+    if os.path.isfile(direct):
+        return direct
+
+    current = [base]
+    for _ in range(max(0, int(max_depth))):
+        children = []
+        for directory in current:
+            try:
+                entries = list(os.scandir(directory))
+            except OSError:
+                continue
+            for entry in entries:
+                try:
+                    if not entry.is_dir():
+                        continue
+                except OSError:
+                    continue
+                candidate = os.path.join(entry.path, name)
+                if os.path.isfile(candidate):
+                    return candidate
+                children.append(entry.path)
+        if not children:
+            break
+        current = children
+    return ""
+
+
 def models_path(*parts: str) -> str:
     return first_existing_path(
         join_root("models", *parts),

--- a/app/services/resource_download_service.py
+++ b/app/services/resource_download_service.py
@@ -9,7 +9,15 @@ import time
 import uuid
 from pathlib import Path
 
-from runtime_paths import app_path, bin_path, bundle_root, join_root, models_path, subprocess_hidden_kwargs
+from runtime_paths import (
+    app_path,
+    bin_path,
+    bundle_root,
+    find_resource_file,
+    join_root,
+    models_path,
+    subprocess_hidden_kwargs,
+)
 
 
 class ResourceDownloadService:
@@ -18,6 +26,10 @@ class ResourceDownloadService:
         "small": "models--Systran--faster-whisper-small.zip",
         "medium": "models--Systran--faster-whisper-medium.zip",
     }
+
+    # A single DLL that only ships inside the GPU pack, used to tell whether
+    # the pack is present regardless of how deeply it was extracted.
+    CUDA_RUNTIME_PROBE = "cublas64_12.dll"
 
     HF_RESOURCE_REPO = os.getenv("CAPCAP_RESOURCE_REPO", "Hacht/CapCapResource").strip() or "Hacht/CapCapResource"
     HF_RESOURCE_REVISION = os.getenv("CAPCAP_RESOURCE_REVISION", "main").strip() or "main"
@@ -245,6 +257,18 @@ class ResourceDownloadService:
                 continue
         return len(seen_names)
 
+    def _find_resource_file(self, root: str, filename: str, max_depth: int = 2) -> str:
+        return find_resource_file(root, filename, max_depth)
+
+    def cuda_runtime_dir(self) -> str:
+        """Return the folder that actually holds the CUDA runtime DLLs.
+
+        Faster-Whisper loads these through PATH, so a nested extraction has to
+        resolve to the real directory rather than just be detected.
+        """
+        located = self._find_resource_file(join_root("bin", "cuda12_fw"), self.CUDA_RUNTIME_PROBE)
+        return os.path.dirname(located) if located else ""
+
     def _whisper_cache_root(self) -> str:
         return models_path("faster_whisper")
 
@@ -252,16 +276,31 @@ class ResourceDownloadService:
         return models_path("pyannote")
 
     def _speaker_diarization_segmentation_path(self) -> str:
-        return os.path.join(
-            self._speaker_diarization_root(),
-            "model.int8.onnx",
-        )
+        return self._find_resource_file(self._speaker_diarization_root(), "model.int8.onnx")
 
     def _speaker_diarization_embedding_path(self) -> str:
-        return os.path.join(
+        return self._find_resource_file(
             self._speaker_diarization_root(),
             "3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx",
         )
+
+    def _sensevoice_root(self) -> str:
+        return models_path("sensevoice")
+
+    def _sensevoice_model_path(self) -> str:
+        return self._find_resource_file(self._sensevoice_root(), "model.int8.onnx")
+
+    def _sensevoice_tokens_path(self) -> str:
+        return self._find_resource_file(self._sensevoice_root(), "tokens.txt")
+
+    def sensevoice_model_dir(self) -> str:
+        """Return the folder Sherpa should load SenseVoice from.
+
+        Falls back to the nominal folder so the loader still produces its own
+        error message when nothing is installed at all.
+        """
+        located = self._sensevoice_model_path()
+        return os.path.dirname(located) if located else self._sensevoice_root()
 
     def _whisper_cache_dirs(self, model_name: str) -> list[str]:
         root = Path(self._whisper_cache_root())
@@ -338,13 +377,17 @@ class ResourceDownloadService:
     def validate_sensevoice_runtime(self) -> list[tuple[str, str]]:
         """Return actionable first-run checks for the bundled default ASR."""
         issues: list[tuple[str, str]] = []
-        model_dir = models_path("sensevoice")
-        model_path = os.path.join(model_dir, "model.int8.onnx")
-        tokens_path = os.path.join(model_dir, "tokens.txt")
-        if not os.path.isfile(model_path):
-            issues.append(("sensevoice:model", f"SenseVoice model is missing: {model_path}"))
-        if not os.path.isfile(tokens_path):
-            issues.append(("sensevoice:tokens", f"SenseVoice tokens file is missing: {tokens_path}"))
+        model_dir = self._sensevoice_root()
+        if not self._sensevoice_model_path():
+            issues.append((
+                "sensevoice:model",
+                f"SenseVoice model (model.int8.onnx) is missing under: {model_dir}",
+            ))
+        if not self._sensevoice_tokens_path():
+            issues.append((
+                "sensevoice:tokens",
+                f"SenseVoice tokens file (tokens.txt) is missing under: {model_dir}",
+            ))
         try:
             import sherpa_onnx  # noqa: F401
         except Exception as exc:
@@ -527,16 +570,41 @@ class ResourceDownloadService:
                 "description": "Speech-recognition model used to create the original transcript.",
             },
             {
+                # SenseVoice gates New Project in both CPU and GPU mode, so it
+                # has to be installable from here. Without an entry the
+                # launcher pointed users at a screen that could not fix it.
+                "id": "sensevoice:model",
+                "name": "SenseVoice Model (default transcription)",
+                "kind": "sensevoice",
+                "required_for": "CPU Mode and GPU Mode",
+                "status": "installed" if self.is_resource_installed("sensevoice:model") else "missing",
+                "target_dir": self._sensevoice_root(),
+                "download_url": f"https://huggingface.co/{self.SENSEVOICE_REPO}/tree/main",
+                "expected_filename": "model.int8.onnx + tokens.txt",
+                "auto_download_supported": True,
+                "description": (
+                    "Default speech-recognition model. Required before a project can be created "
+                    "in either CPU or GPU mode."
+                ),
+            },
+            {
                 "id": "cuda:whisper",
                 "name": "GPU Acceleration Pack (CUDA 12, ~1.6 GB)",
                 "kind": "cuda",
                 "required_for": "GPU Mode",
                 "status": "installed" if self.is_resource_installed("cuda:whisper") else "missing",
-                "target_dir": join_root("bin", "cuda12_fw"),
+                # The archive contains its own cuda12_fw/ folder, so it must be
+                # extracted into bin/. Naming bin/cuda12_fw here sent manual
+                # installers one level too deep and the pack read as missing.
+                "target_dir": join_root("bin"),
                 "download_url": self._hf_blob_url("zipResource/cuda12_fw.zip"),
                 "expected_filename": "cuda12_fw.zip",
                 "auto_download_supported": True,
-                "description": "Required for GPU Mode. Provides the CUDA runtime used to accelerate supported local processing.",
+                "description": (
+                    "Required for GPU Mode. Provides the CUDA runtime used to accelerate supported "
+                    "local processing. Extract the ZIP into this folder - it creates the cuda12_fw "
+                    "subfolder itself."
+                ),
             },
             {
                 "id": "diarization:segmentation",
@@ -604,14 +672,13 @@ class ResourceDownloadService:
         if resource_id == "ocr:engine":
             return self.is_ocr_ready()
         if resource_id == "cuda:whisper":
-            fw_dir = join_root("bin", "cuda12_fw")
-            return os.path.exists(os.path.join(fw_dir, "cublas64_12.dll"))
+            return bool(self.cuda_runtime_dir())
         if resource_id == "sensevoice:model":
-            return os.path.isfile(os.path.join(models_path("sensevoice"), "model.int8.onnx"))
+            return bool(self._sensevoice_model_path())
         if resource_id == "diarization:segmentation":
-            return os.path.isfile(self._speaker_diarization_segmentation_path())
+            return bool(self._speaker_diarization_segmentation_path())
         if resource_id == "diarization:embedding":
-            return os.path.isfile(self._speaker_diarization_embedding_path())
+            return bool(self._speaker_diarization_embedding_path())
         if resource_id.startswith("whisper:"):
             model_name = resource_id.split(":", 1)[1].strip().lower()
             for model_dir in self._whisper_cache_dirs(model_name):
@@ -621,10 +688,12 @@ class ResourceDownloadService:
                 except Exception:
                     continue
             return False
+        # Match the count shown in Manage Resources: a language is usable as
+        # soon as one voice loads, not only when the whole catalog is present.
         if resource_id == "voice:pack":
-            return self._voice_pack_status("vi") == "installed"
+            return self._usable_piper_voice_count("vi") > 0
         if resource_id == "voice:pack-en":
-            return self._voice_pack_status("en") == "installed"
+            return self._usable_piper_voice_count("en") > 0
         if resource_id.startswith("voice:"):
             voice_id = resource_id.split(":", 1)[1].strip()
             voice_entry = self._find_voice_entry(voice_id)
@@ -699,6 +768,35 @@ class ResourceDownloadService:
             raise ValueError(
                 "Whisper models are downloaded manually. Use Open Download Page, then extract the ZIP into models/faster_whisper."
             )
+
+        if resource_id == "sensevoice:model":
+            try:
+                from huggingface_hub import hf_hub_download, hf_hub_url
+                from huggingface_hub.file_download import get_hf_file_metadata
+            except Exception as exc:
+                raise ImportError(
+                    "huggingface_hub is not installed. Run `pip install huggingface_hub` first."
+                ) from exc
+            target_dir = self._sensevoice_root()
+            os.makedirs(target_dir, exist_ok=True)
+            files = [("model.int8.onnx", 0, 90), ("tokens.txt", 90, 100)]
+            for filename, start_percent, end_percent in files:
+                self._download_hf_file(
+                    repo_id=self.SENSEVOICE_REPO,
+                    revision="main",
+                    filename=filename,
+                    local_dir=target_dir,
+                    hf_hub_download=hf_hub_download,
+                    hf_hub_url=hf_hub_url,
+                    get_hf_file_metadata=get_hf_file_metadata,
+                    progress_cb=progress_cb,
+                    start_percent=start_percent,
+                    end_percent=end_percent,
+                    label=f"Downloading {filename}",
+                )
+            if progress_cb:
+                progress_cb(100, "SenseVoice model is ready.")
+            return
 
         if resource_id == "cuda:whisper":
             zip_url = self._hf_blob_url("zipResource/cuda12_fw.zip")

--- a/app/services/speaker_diarization_service.py
+++ b/app/services/speaker_diarization_service.py
@@ -4,7 +4,7 @@ import os
 
 import numpy as np
 
-from runtime_paths import models_path
+from runtime_paths import find_resource_file, models_path
 
 
 class SpeakerDiarizationService:
@@ -25,7 +25,12 @@ class SpeakerDiarizationService:
     @classmethod
     def _model_path(cls, env_name: str, filename: str) -> str:
         configured = str(os.getenv(env_name, "") or "").strip()
-        return os.path.abspath(configured) if configured else models_path(cls.DEFAULT_MODEL_DIR, filename)
+        if configured:
+            return os.path.abspath(configured)
+        # The Sherpa-ONNX archives carry their own folder, so accept the model
+        # whether it sits directly in models/pyannote or one level below.
+        located = find_resource_file(models_path(cls.DEFAULT_MODEL_DIR), filename)
+        return located or models_path(cls.DEFAULT_MODEL_DIR, filename)
 
     @classmethod
     def model_paths(cls) -> tuple[str, str]:

--- a/app/whisper_processor.py
+++ b/app/whisper_processor.py
@@ -5,7 +5,7 @@ import threading
 import traceback
 from pathlib import Path
 
-from runtime_paths import bin_path, models_path, workspace_root, subprocess_hidden_kwargs
+from runtime_paths import find_resource_file, bin_path, models_path, workspace_root, subprocess_hidden_kwargs
 from services.resource_download_service import ResourceDownloadService
 
 
@@ -132,6 +132,13 @@ def _candidate_cuda_bin_dirs() -> list[str]:
     workspace_cuda_bin = _workspace_root() / "bin" / "cuda12_fw"
     if workspace_cuda_bin.exists():
         candidates.append(str(workspace_cuda_bin))
+    # Extracting cuda12_fw.zip into bin/cuda12_fw (rather than into bin/)
+    # nests the DLLs one level down. Detecting that layout is not enough --
+    # the loader needs the directory that actually holds the runtime.
+    for root in (bundled_cuda_bin, str(workspace_cuda_bin)):
+        located = find_resource_file(root, "cublas64_12.dll")
+        if located:
+            candidates.append(os.path.dirname(located))
     toolkit_root = str(os.getenv("CUDAToolkit_ROOT", "")).strip()
     if toolkit_root:
         candidates.append(os.path.join(toolkit_root, "bin"))

--- a/app/workflows/prepare_workflow.py
+++ b/app/workflows/prepare_workflow.py
@@ -5,7 +5,7 @@ import re
 import subprocess
 import time
 
-from runtime_paths import bin_path, models_path, subprocess_hidden_kwargs
+from runtime_paths import bin_path, subprocess_hidden_kwargs
 from runtime_profile import is_remote_profile
 from services import ChunkingService, EngineRuntime, ProjectService, SegmentRegroupService, SegmentService
 from services.resource_download_service import ResourceDownloadService
@@ -368,7 +368,11 @@ class PrepareWorkflow:
             # bundles the ready-to-use SenseVoice model under _internal.
             # Never construct workspace_root/models directly here or the
             # frozen worker will miss its bundled model at Transcript time.
-            sensevoice_model_dir = models_path("sensevoice")
+            # Resolving through the resource service also accepts a pack that
+            # was extracted one level deeper than the nominal folder.
+            sensevoice_model_dir = ResourceDownloadService(
+                self.workspace_root
+            ).sensevoice_model_dir()
         # Faster-Whisper accepts a model name (for example ``base``) or a
         # resolved local model directory. Do not prepend ``models/`` here:
         # doing so turns a selected Base/Small model into an invalid path and

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -15,16 +15,24 @@ No CUDA Toolkit installation is required when the CUDA runtime pack is installed
 
 ## Resource Manager
 
-Open **Manage Resources** from the launcher or Settings. It reports each resource as Ready, Partial, or Missing and provides download links.
+Open **Manage Resources** from the launcher or Settings. It reports each resource as Ready, Partial, or Missing and provides download links. Every entry shows the folder it installs into, and **Open Folder** opens that folder directly.
 
-| Resource | Target folder |
-| --- | --- |
-| Faster-Whisper models | `models/faster_whisper/` |
-| CUDA 12 runtime pack | `bin/cuda12_fw/` |
-| SenseVoice model | `models/sensevoice/` |
-| Vietnamese Piper voices | `models/piper/` |
-| English Piper voices | `models/piper-en/` |
-| Speaker diarization models | `models/pyannote/` |
+The SenseVoice model is required before **New Project** is enabled, in both CPU and GPU mode. The GPU Acceleration Pack is required only for GPU mode.
+
+| Resource | Extract the archive into | Files end up in |
+| --- | --- | --- |
+| Faster-Whisper models | `models/faster_whisper/` | `models/faster_whisper/models--Systran--.../` |
+| CUDA 12 runtime pack | `bin/` | `bin/cuda12_fw/` |
+| SenseVoice model | `models/sensevoice/` | `models/sensevoice/` |
+| Vietnamese Piper voices | `models/piper/` | `models/piper/` |
+| English Piper voices | `models/piper-en/` | `models/piper-en/` |
+| Speaker diarization models | `models/pyannote/` | `models/pyannote/` |
+
+### Installing a pack by hand
+
+The archives carry their own top-level folder. `cuda12_fw.zip`, for example, contains a `cuda12_fw/` directory, so it must be extracted into `bin/` and **not** into `bin/cuda12_fw/` - the latter produces `bin/cuda12_fw/cuda12_fw/`.
+
+CapCap now also accepts a pack nested one or two levels below its target folder, so an accidental extra folder no longer leaves the resource stuck on Missing. Press **Refresh** in Manage Resources after copying files in.
 
 ## Environment configuration
 

--- a/ui/views/resource_manager.py
+++ b/ui/views/resource_manager.py
@@ -279,10 +279,22 @@ def open_resource_manager(workspace_root: str = None, parent=None,
         dialog._resource_rows = {}
 
         resources = service.list_resources()
-        cpu_items = [r for r in resources if r.get("kind") in {"sensevoice", "whisper_cpu"}]
+        cpu_kinds = {"sensevoice", "whisper_cpu"}
         gpu_kinds = {"ai", "whisper", "cuda"}
+        diarization_kinds = {"diarization"}
+        voice_kinds = {"voice"}
+
+        cpu_items = [r for r in resources if r.get("kind") in cpu_kinds]
         gpu_items = [r for r in resources if r.get("kind") in gpu_kinds]
-        voice_items = [r for r in resources if r.get("kind") == "voice"]
+        diarization_items = [r for r in resources if r.get("kind") in diarization_kinds]
+        voice_items = [r for r in resources if r.get("kind") in voice_kinds]
+
+        # A resource whose kind matched no section used to be dropped without
+        # a trace, which is how the speaker-diarization entries stayed
+        # invisible while still being offered by the service. Collect the
+        # leftovers so adding a resource can never silently hide it again.
+        known_kinds = cpu_kinds | gpu_kinds | diarization_kinds | voice_kinds
+        other_items = [r for r in resources if r.get("kind") not in known_kinds]
 
         if cpu_items:
             cpu_card, cpu_layout = _make_section("CPU Resource", expanded=True)
@@ -301,8 +313,24 @@ def open_resource_manager(workspace_root: str = None, parent=None,
                 _add_card(item, gpu_layout)
             content_layout.addWidget(gpu_card)
 
+        if diarization_items:
+            # Optional: diarization only affects per-speaker voice assignment,
+            # so it starts collapsed like the GPU section.
+            diarization_card, diarization_layout = _make_section(
+                "Speaker Diarization (optional)", expanded=False
+            )
+            for item in diarization_items:
+                _add_card(item, diarization_layout)
+            content_layout.addWidget(diarization_card)
+
         for item in voice_items:
             _add_card(item, content_layout)
+
+        if other_items:
+            other_card, other_layout = _make_section("Other Resources", expanded=False)
+            for item in other_items:
+                _add_card(item, other_layout)
+            content_layout.addWidget(other_card)
 
         content_layout.addStretch()
 


### PR DESCRIPTION
Follow-up on the three closed issues — #4, #5 and #6. Each was answered in the thread, but the code cause is still present in `main`, so the next user hits the same wall. This fixes the causes.

## #5 — New Project blocked, with no way to unblock it

`get_device_requirements()` requires `sensevoice:model` in **both** CPU and GPU mode. But SenseVoice had:

- no entry in `list_resources()` → invisible in Manage Resources
- no branch in `download_resource()` → not installable by the app at all

So the launcher disabled **New Project** and showed *"CPU mode needs: SenseVoice model. Open Manage Resources to set them up"* — pointing at a screen that could not fix it. That matches the report exactly: *"Cái nút New Project không bấm được á bạn, nhấn nó báo qua tab Manage Resource tải."*

SenseVoice is now listed and auto-downloads from `SENSEVOICE_REPO`. Notably `resource_manager.py` already grouped a `"sensevoice"` kind under **CPU Resource** — the entry it expected was simply never added, which is what makes this look like an oversight rather than a design choice.

## #6 — GPU pack reported missing after a correct-looking manual install

The Resource Manager advertised the CUDA pack's target folder as `bin/cuda12_fw`, and its **Open Folder** button opened it. But `cuda12_fw.zip` contains its own top-level `cuda12_fw/` directory, so it must be extracted into `bin/`. I verified this against the published archive by reading its central directory:

```
zip size: 1,161,150,107 bytes   entries: 14
Top-level entries:  cuda12_fw   (14 entries)
cublas64_12.dll path:  cuda12_fw/cublas64_12.dll
```

Following the UI therefore produced `bin/cuda12_fw/cuda12_fw/cublas64_12.dll`, and `is_resource_installed()` checked one exact path — so the pack read as **Missing** permanently, with GPU stuck at N/A. The app's own auto-download was fine (it extracts into `bin/`); only the manual route was trapped, which is why the thread ended in a back-and-forth about where to put the files.

The advertised folder is corrected to `bin/`, the description states that the ZIP creates the subfolder itself, and detection now tolerates the nested layout.

## Detection no longer breaks on an extra folder level

`find_resource_file()` (new, in `runtime_paths`) searches a resource folder and up to two levels below it. Applied to the CUDA pack, SenseVoice, and the speaker-diarization models — all three ship as archives carrying their own top-level folder, so the same trap applied to each. The diarization pack is manual-install only, so it hit this every time.

Detecting a nested pack is not sufficient on its own — the runtime has to load from the right place — so the consumers were pointed at the resolved directory too:

- Faster-Whisper's CUDA PATH setup (`_candidate_cuda_bin_dirs`)
- SenseVoice's model directory in `prepare_workflow`
- `SpeakerDiarizationService.model_paths()`

Also, `is_resource_installed("voice:pack")` now matches the count the Resource Manager displays (usable voices) instead of demanding the whole catalog — the two disagreed after the V7.1 status fix.

## Diarization resources were never rendered

`_populate()` in the Resource Manager partitioned resources into CPU / GPU / voice sections by `kind` and silently dropped anything matching none of them. `kind: "diarization"` matched no section, so both speaker-diarization entries were built by the service, checked by `is_resource_installed()`, and listed in `requirements.md` — but never appeared in the UI. No status, no download link, no way to reach them.

They now get their own collapsed **Speaker Diarization (optional)** section, next to GPU rather than in the always-expanded CPU group, since diarization only affects per-speaker voice assignment.

The silent drop is the more dangerous half, so unmatched kinds now fall through to an **Other Resources** section. Adding a resource can no longer hide it by forgetting to extend a filter.

## #4 — no EXE in the repository

README gained a **Download** section pointing at the Releases page, plus a note to install the required packs from Manage Resources on first launch.

## Verification

Each failure was reproduced against `main` and re-run on this branch:

| Case | main | this branch |
| --- | --- | --- |
| nested CUDA pack detected | `False` | `True` |
| nested SenseVoice detected | `False` | `True` |
| SenseVoice offered in Manage Resources | `False` | `True` |
| CUDA target folder shown to user | `bin\cuda12_fw` | `bin` |
| nested diarization model detected | `False` | `True` |
| diarization entries rendered in Manage Resources | `False` | `True` |

The display fix was checked by comparing the `kind` values `list_resources()` emits against the sets `_populate()` partitions on: on `main`, `diarization` was emitted with no matching section; now every emitted kind has one, the sections stay mutually exclusive, and a catch-all covers anything new.

Also checked: flat (correct) layouts still detect; a genuinely absent pack still reads as missing; `find_resource_file` respects its depth bound and handles missing roots/empty args; every CPU and GPU requirement is now reachable from Manage Resources; `compileall` clean and `pyflakes` shows no new findings versus `main`.

## Notes

- I could not run the GUI end-to-end (no PySide6 on this machine), so the verification is at the service layer — the layer that decides Ready/Partial/Missing and gates New Project. A UI smoke test would be worth doing before release.
- This branch touches `app/runtime_paths.py`, `README.md` and `docs/requirements.md`, which #7 also touches. They are independent changes; expect a small conflict in `runtime_paths.py` on whichever merges second.
